### PR TITLE
Add NES 2.0 header support

### DIFF
--- a/hires.txt
+++ b/hires.txt
@@ -1,6 +1,7 @@
 <ver>106
 <scale>1
 <patch>Megaman - Super.ips,2F88381557339A14C20428455F6991C1EB902C99
+<patch>Megaman - Super.ips,51A9FE7B5CB82833FC416E0F29B965495D9CE49A
 
 #Hires version: 2.1.4
 


### PR DESCRIPTION
Unfortunately the HD pack structure relies on a headered hash, which means iNES and NES 2.0 hashes need to be listed separately. This simply adds that, using the header generated via the NES 2.0 header database:
https://forums.nesdev.com/viewtopic.php?f=3&t=19940